### PR TITLE
Add additional network sockets configuration for Init, Min and Max

### DIFF
--- a/A3ServerTool/Attributes/ConfigProperty.cs
+++ b/A3ServerTool/Attributes/ConfigProperty.cs
@@ -14,6 +14,11 @@ namespace A3ServerTool.Attributes
         public string PropertyName { get; set; }
 
         /// <summary>
+        ///  Parent class while parsing.
+        /// </summary>
+        public string Parent { get; set; }
+
+        /// <summary>
         /// Gets or sets a value for enabling/disabling property parsing.
         /// </summary>
         public bool IgnoreParsing { get; set; }

--- a/A3ServerTool/Helpers/UniversalParser.cs
+++ b/A3ServerTool/Helpers/UniversalParser.cs
@@ -41,7 +41,8 @@ namespace A3ServerTool.Helpers
 
                     if (configProperty?.IgnoreParsing != false) continue;
 
-                    nameToValueDictionary.TryGetValue(configProperty.PropertyName, out var value);
+                    var name = string.IsNullOrEmpty(configProperty.Parent) ? configProperty.PropertyName : configProperty.Parent + configProperty.PropertyName;
+                    nameToValueDictionary.TryGetValue(name, out var value);
 
                     if (value == null) continue;
 
@@ -364,6 +365,7 @@ namespace A3ServerTool.Helpers
         private Dictionary<string, string> ConvertFromTextToDictionary(string[] textProperties, Type type)
         {
             var nameToValueDictionary = new Dictionary<string, string>();
+            var parent = "";
 
             for (int i = 0; i < textProperties.Length; i++)
             {
@@ -371,6 +373,8 @@ namespace A3ServerTool.Helpers
                     .Where(x => x != "=")
                     .Select(x => x.Trim())
                     .ToArray();
+                if (splittedProperty[0].StartsWith("class ")) parent = splittedProperty[0].Substring("class ".Length);
+                if (splittedProperty[0].StartsWith("};")) parent = "";
                 if (splittedProperty.Length != 2) continue;
 
                 if (splittedProperty[0].Contains("[]"))
@@ -382,7 +386,7 @@ namespace A3ServerTool.Helpers
                         if (textProperties[j] == "};")
                         {
                             value = Regex.Replace(value, @"[^\S ]+", "");
-                            nameToValueDictionary.Add(splittedProperty[0], value?.Replace("\"", string.Empty));
+                            nameToValueDictionary.Add(parent + splittedProperty[0], value?.Replace("\"", string.Empty));
                             break;
                         }
 
@@ -407,7 +411,7 @@ namespace A3ServerTool.Helpers
                         splittedProperty[1] = splittedProperty[1].Replace(";", string.Empty);
                     }
 
-                    nameToValueDictionary.Add(splittedProperty[0], splittedProperty[1]);
+                    nameToValueDictionary.Add(parent + splittedProperty[0], splittedProperty[1]);
                 }
             }
 

--- a/A3ServerTool/Models/Config/BasicConfig.cs
+++ b/A3ServerTool/Models/Config/BasicConfig.cs
@@ -104,14 +104,14 @@ namespace A3ServerTool.Models.Config
         /// <summary>
         /// Maximum packet size
         /// </summary>
-        [ConfigProperty(PropertyName = "maxPacketSize")]
+        [ConfigProperty(PropertyName = "maxPacketSize", Parent = "sockets")]
         [WrappingClass(new string[] { "sockets" })]
         public int? SocketsMaxPacketSize { get; set; } = 1400;
 
         /// <summary>
         /// Maximum packet size
         /// </summary>
-        [ConfigProperty(PropertyName = "initBandwidth")]
+        [ConfigProperty(PropertyName = "initBandwidth", Parent = "sockets")]
         [WrappingClass(new string[] { "sockets" })]
         public int? SocketsInitBandwidth { get; set; } = 1250000;
 
@@ -120,7 +120,7 @@ namespace A3ServerTool.Models.Config
         /// This value helps server to estimate bandwidth available.
         /// Increasing it to too optimistic values can increase lag and CPU load, as too many messages will be sent but discarded.
         /// </summary>
-        [ConfigProperty(PropertyName = "MinBandwidth")]
+        [ConfigProperty(PropertyName = "MinBandwidth", Parent = "sockets")]
         [WrappingClass(new string[] { "sockets" })]
         public int? SocketsMinBandwidth { get; set; } = 65536;
 
@@ -128,7 +128,7 @@ namespace A3ServerTool.Models.Config
         /// Bandwidth the server is guaranteed to never have (in bps).
         /// This value helps the server to estimate bandwidth available.
         /// </summary>
-        [ConfigProperty(PropertyName = "MaxBandwidth")]
+        [ConfigProperty(PropertyName = "MaxBandwidth", Parent = "sockets")]
         [WrappingClass(new string[] { "sockets" })]
         public int? SocketsMaxBandwidth { get; set; } = 6250000;
 

--- a/A3ServerTool/Models/Config/BasicConfig.cs
+++ b/A3ServerTool/Models/Config/BasicConfig.cs
@@ -106,7 +106,31 @@ namespace A3ServerTool.Models.Config
         /// </summary>
         [ConfigProperty(PropertyName = "maxPacketSize")]
         [WrappingClass(new string[] { "sockets" })]
-        public int? MaxPacketSize { get; set; } = 1400;
+        public int? SocketsMaxPacketSize { get; set; } = 1400;
+
+        /// <summary>
+        /// Maximum packet size
+        /// </summary>
+        [ConfigProperty(PropertyName = "initBandwidth")]
+        [WrappingClass(new string[] { "sockets" })]
+        public int? SocketsInitBandwidth { get; set; } = 1250000;
+
+        /// <summary>
+        /// Bandwidth the server is guaranteed to have (in bps).
+        /// This value helps server to estimate bandwidth available.
+        /// Increasing it to too optimistic values can increase lag and CPU load, as too many messages will be sent but discarded.
+        /// </summary>
+        [ConfigProperty(PropertyName = "MinBandwidth")]
+        [WrappingClass(new string[] { "sockets" })]
+        public int? SocketsMinBandwidth { get; set; } = 65536;
+
+        /// <summary>
+        /// Bandwidth the server is guaranteed to never have (in bps).
+        /// This value helps the server to estimate bandwidth available.
+        /// </summary>
+        [ConfigProperty(PropertyName = "MaxBandwidth")]
+        [WrappingClass(new string[] { "sockets" })]
+        public int? SocketsMaxBandwidth { get; set; } = 6250000;
 
         //TODO: check where it is actually belong - basic.cfg or armaprofile config?
         /// <summary>

--- a/A3ServerTool/Resources/Lang.de-DE.xaml
+++ b/A3ServerTool/Resources/Lang.de-DE.xaml
@@ -249,8 +249,17 @@
     <v:String x:Key="LocalizableMinErrorToSendNearTitle">Minimum Error To Send Near</v:String>
     <v:String x:Key="LocalizableMinErrorToSendNearTooltip">Minimaler Fehler beim Senden von Updates über das Netzwerk für Geräte in der Nähe. Die Verwendung eines höheren Werts kann den für nahe Einheiten gesendeten Datenverkehr verringern.</v:String>
 
-    <v:String x:Key="LocalizableMaxPacketSizeTitle">Maximum Packet Size</v:String>
-    <v:String x:Key="LocalizableMaxPacketSizeTooltip">Maximale Größe des über das Netzwerk gesendeten Pakets. Bitte nur verwenden, wenn Ihr Router oder ISP eine geringere Paketgröße erzwingt und Sie Verbindungsprobleme mit dem Spiel haben. Desync kann auftreten, wenn MaxSizeGuaranteed / MaxSizeNonguaranteed-Werte über maxPacketSize verwendet werden.</v:String>
+    <v:String x:Key="LocalizableSocketsMaxPacketSizeTitle">Sockets Maximum Packet Size</v:String>
+    <v:String x:Key="LocalizableSocketsMaxPacketSizeTooltip">Maximale Größe des über das Netzwerk gesendeten Pakets. Bitte nur verwenden, wenn Ihr Router oder ISP eine geringere Paketgröße erzwingt und Sie Verbindungsprobleme mit dem Spiel haben. Desync kann auftreten, wenn MaxSizeGuaranteed / MaxSizeNonguaranteed-Werte über maxPacketSize verwendet werden.</v:String>
+
+    <v:String x:Key="LocalizableSocketsInitBandwidthTitle">Sockets Init Bandwidth per Client</v:String>
+    <v:String x:Key="LocalizableSocketsInitBandwidthTooltip">Initial bandwidth per Client. Should be equal to or more than min bandwidth per client and equal to or les than max bandwidth per client.</v:String>
+
+    <v:String x:Key="LocalizableSocketsMinBandwidthTitle">Sockets Minimum Bandwidth</v:String>
+    <v:String x:Key="LocalizableSocketsMinBandwidthTooltip">Minimum bandwidth per Client.</v:String>
+
+    <v:String x:Key="LocalizableSocketsMaxBandwidthTitle">Sockets Maximum Bandwidth</v:String>
+    <v:String x:Key="LocalizableSocketsMaxBandwidthTooltip">Minimum bandwidth per Client.</v:String>
 
     <v:String x:Key="LocalizableCustomFileSizeTitle">Maximum Custom File Size</v:String>
     <v:String x:Key="LocalizableCustomFileSizeTooltip">Benutzer mit benutzerdefiniertem Gesicht oder benutzerdefiniertem Sound, der größer als diese Größe ist, werden beim Verbindungsversuch gekickt.</v:String>

--- a/A3ServerTool/Resources/Lang.ru-RU.xaml
+++ b/A3ServerTool/Resources/Lang.ru-RU.xaml
@@ -249,8 +249,17 @@
     <v:String x:Key="LocalizableMinErrorToSendNearTitle">Минимальная ошибка для отправки рядом</v:String>
     <v:String x:Key="LocalizableMinErrorToSendNearTooltip">Минимальная ошибка для отправки обновления статуса по сети для ближайших юнитов. Использование большего значения может уменьшить траффик, посылаемый ближайшим юнитам.</v:String>
 
-    <v:String x:Key="LocalizableMaxPacketSizeTitle">Максимальный размер пакета</v:String>
-    <v:String x:Key="LocalizableMaxPacketSizeTooltip">Максимальный размер пакета, отправляемого по сети. Использовать лишь в том случае если ваш роутер или провайдер требуют меньшего значения и/или у вас проблемы с соединением. Может случиться десинхронизация в случае если максимальный размер гарантированного/негарантированного пакетов больше чем максимальный размер пакета.</v:String>
+    <v:String x:Key="LocalizableSocketsMaxPacketSizeTitle">Максимальный размер пакета</v:String>
+    <v:String x:Key="LocalizableSocketsMaxPacketSizeTooltip">Максимальный размер пакета, отправляемого по сети. Использовать лишь в том случае если ваш роутер или провайдер требуют меньшего значения и/или у вас проблемы с соединением. Может случиться десинхронизация в случае если максимальный размер гарантированного/негарантированного пакетов больше чем максимальный размер пакета.</v:String>
+
+    <v:String x:Key="LocalizableSocketsInitBandwidthTitle">Sockets Init Bandwidth per Client</v:String>
+    <v:String x:Key="LocalizableSocketsInitBandwidthTooltip">Initial bandwidth per Client. Should be equal to or more than min bandwidth per client and equal to or les than max bandwidth per client.</v:String>
+
+    <v:String x:Key="LocalizableSocketsMinBandwidthTitle">Sockets Minimum Bandwidth</v:String>
+    <v:String x:Key="LocalizableSocketsMinBandwidthTooltip">Minimum bandwidth per Client.</v:String>
+
+    <v:String x:Key="LocalizableSocketsMaxBandwidthTitle">Sockets Maximum Bandwidth</v:String>
+    <v:String x:Key="LocalizableSocketsMaxBandwidthTooltip">Minimum bandwidth per Client.</v:String>
 
     <v:String x:Key="LocalizableCustomFileSizeTitle">Максимальный размер пользовательских файлов</v:String>
     <v:String x:Key="LocalizableCustomFileSizeTooltip">Пользователи с текстурой лица или звуками при превышении указанного значении будут изгнаны из игры при подключении.</v:String>

--- a/A3ServerTool/Resources/Lang.xaml
+++ b/A3ServerTool/Resources/Lang.xaml
@@ -249,8 +249,17 @@
     <v:String x:Key="LocalizableMinErrorToSendNearTitle">Minimum Error To Send Near</v:String>
     <v:String x:Key="LocalizableMinErrorToSendNearTooltip">Minimal error to send updates across network for near units. Using larger value can reduce traffic sent for near units.</v:String>
 
-    <v:String x:Key="LocalizableMaxPacketSizeTitle">Maximum Packet Size</v:String>
-    <v:String x:Key="LocalizableMaxPacketSizeTooltip">Maximal size of packet sent over network. Use please only in case Your router or ISP enforce lower packet size and You have connectivity issues with game. Desync might happen if used MaxSizeGuaranteed/MaxSizeNonguaranteed values over the maxPacketSize.</v:String>
+    <v:String x:Key="LocalizableSocketsMaxPacketSizeTitle">Sockets Maximum Packet Size</v:String>
+    <v:String x:Key="LocalizableSocketsMaxPacketSizeTooltip">Maximal size of packet sent over network. Use please only in case Your router or ISP enforce lower packet size and You have connectivity issues with game. Desync might happen if used MaxSizeGuaranteed/MaxSizeNonguaranteed values over the maxPacketSize.</v:String>
+
+    <v:String x:Key="LocalizableSocketsInitBandwidthTitle">Sockets Init Bandwidth per Client</v:String>
+    <v:String x:Key="LocalizableSocketsInitBandwidthTooltip">Initial bandwidth per Client. Should be equal to or more than min bandwidth per client and equal to or les than max bandwidth per client.</v:String>
+
+    <v:String x:Key="LocalizableSocketsMinBandwidthTitle">Sockets Minimum Bandwidth</v:String>
+    <v:String x:Key="LocalizableSocketsMinBandwidthTooltip">Minimum bandwidth per Client.</v:String>
+
+    <v:String x:Key="LocalizableSocketsMaxBandwidthTitle">Sockets Maximum Bandwidth</v:String>
+    <v:String x:Key="LocalizableSocketsMaxBandwidthTooltip">Minimum bandwidth per Client.</v:String>
 
     <v:String x:Key="LocalizableCustomFileSizeTitle">Maximum Custom File Size</v:String>
     <v:String x:Key="LocalizableCustomFileSizeTooltip">Users with custom face or custom sound larger than this size are kicked when trying to connect.</v:String>

--- a/A3ServerTool/ViewModels/ServerSubViewModels/NetworkViewModel.cs
+++ b/A3ServerTool/ViewModels/ServerSubViewModels/NetworkViewModel.cs
@@ -104,13 +104,46 @@ namespace A3ServerTool.ViewModels.ServerSubViewModels
             }
         }
 
-        public int? MaxPacketSize
+        public int? SocketsMaxPacketSize
         {
-            get => CurrentProfile.BasicConfig.MaxPacketSize;
+            get => CurrentProfile.BasicConfig.SocketsMaxPacketSize;
             set
             {
-                if (Equals(value, CurrentProfile.BasicConfig.MaxPacketSize)) return;
-                CurrentProfile.BasicConfig.MaxPacketSize = value;
+                if (Equals(value, CurrentProfile.BasicConfig.SocketsMaxPacketSize)) return;
+                CurrentProfile.BasicConfig.SocketsMaxPacketSize = value;
+                RaisePropertyChanged();
+            }
+        }
+
+        public int? SocketsInitBandwidth
+        {
+            get => CurrentProfile.BasicConfig.SocketsInitBandwidth;
+            set
+            {
+                if (Equals(value, CurrentProfile.BasicConfig.SocketsInitBandwidth)) return;
+                CurrentProfile.BasicConfig.SocketsInitBandwidth = value;
+                RaisePropertyChanged();
+            }
+        }
+
+        public int? SocketsMinBandwidth
+        {
+            get => CurrentProfile.BasicConfig.SocketsMinBandwidth;
+            set
+            {
+                if (Equals(value, CurrentProfile.BasicConfig.SocketsMinBandwidth)) return;
+                CurrentProfile.BasicConfig.SocketsMinBandwidth = value;
+                RaisePropertyChanged();
+            }
+        }
+
+        public int? SocketsMaxBandwidth
+        {
+            get => CurrentProfile.BasicConfig.SocketsMaxBandwidth;
+            set
+            {
+                if (Equals(value, CurrentProfile.BasicConfig.SocketsMaxBandwidth)) return;
+                CurrentProfile.BasicConfig.SocketsMaxBandwidth = value;
                 RaisePropertyChanged();
             }
         }
@@ -305,8 +338,14 @@ namespace A3ServerTool.ViewModels.ServerSubViewModels
                         return "MinErrorToSend must be more than zero.";
                     case nameof(MaxCustomFileSize) when MaxCustomFileSize < 0:
                         return "MaxCustomFileSize must be more than zero.";
-                    case nameof(MaxPacketSize) when MaxPacketSize < 0:
-                        return "MaxPacketSize must be more than zero.";
+                    case nameof(SocketsMaxPacketSize) when SocketsMaxPacketSize < 0:
+                        return "SocketsMaxPacketSize must be more than zero.";
+                    case nameof(SocketsInitBandwidth) when SocketsInitBandwidth < 0:
+                        return "SocketsInitBandwidth must be more than zero.";
+                    case nameof(SocketsMinBandwidth) when SocketsMinBandwidth < 0:
+                        return "SocketsMinBandwidth must be more than zero.";
+                    case nameof(SocketsMaxBandwidth) when SocketsMaxBandwidth < 0:
+                        return "SocketsMaxBandwidth must be more than zero.";
                     case nameof(SlowNetworkKickRules) when SlowNetworkKickRules?.Replace(",", string.Empty).Length > 4:
                         return "There can be only four network rules.";
                     default:
@@ -351,12 +390,24 @@ namespace A3ServerTool.ViewModels.ServerSubViewModels
                 {
                     return "MaxCustomFileSize must be more than zero.";
                 }
-                if (MaxPacketSize < 0 || MaxPacketSize == null)
+                if (SocketsMaxPacketSize < 0 || SocketsMaxPacketSize == null)
                 {
-                    return "MaxPacketSize must be more than zero.";
+                    return "SocketsMaxPacketSize must be more than zero.";
+                }
+                if (SocketsInitBandwidth < 0 || SocketsInitBandwidth == null)
+                {
+                    return "SocketsInitBandwidth must be more than zero.";
+                }
+                if (SocketsMinBandwidth < 0 || SocketsMinBandwidth == null)
+                {
+                    return "SocketsMinBandwidth must be more than zero.";
+                }
+                if (SocketsMaxBandwidth < 0 || SocketsMaxBandwidth == null)
+                {
+                    return "SocketsMaxBandwidth must be more than zero.";
                 }
 
-                if(string.IsNullOrWhiteSpace(Port))
+                if (string.IsNullOrWhiteSpace(Port))
                 {
                     return "Port must be specified!";
                 }

--- a/A3ServerTool/Views/A3/NetworkView.xaml
+++ b/A3ServerTool/Views/A3/NetworkView.xaml
@@ -232,7 +232,7 @@
                     <Label
                         Margin="{StaticResource LabelMargin}"
                         HorizontalAlignment="Left"
-                        Content="{DynamicResource LocalizableMaxPacketSizeTitle}"
+                        Content="{DynamicResource LocalizableSocketsMaxPacketSizeTitle}"
                         FontSize="14"
                         FontWeight="Bold" />
                     <mah:NumericUpDown
@@ -245,8 +245,62 @@
                         Minimum="0"
                         Speedup="True"
                         TextAlignment="Left"
-                        ToolTip="{DynamicResource LocalizableMaxPacketSizeTooltip}"
-                        Value="{Binding MaxPacketSize, TargetNullValue='', ValidatesOnDataErrors=True, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, NotifyOnValidationError=True}" />
+                        ToolTip="{DynamicResource LocalizableSocketsMaxPacketSizeTooltip}"
+                        Value="{Binding SocketsMaxPacketSize, TargetNullValue='', ValidatesOnDataErrors=True, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, NotifyOnValidationError=True}" />
+
+                    <Label
+                        Margin="{StaticResource LabelMargin}"
+                        HorizontalAlignment="Left"
+                        Content="{DynamicResource LocalizableSocketsInitBandwidthTitle}"
+                        FontSize="14"
+                        FontWeight="Bold" />
+                    <mah:NumericUpDown
+                        MinWidth="192"
+                        MaxWidth="512"
+                        Margin="{StaticResource EndControlMargin}"
+                        HorizontalAlignment="Left"
+                        mah:TextBoxHelper.ClearTextButton="True"
+                        Minimum="0"
+                        Speedup="True"
+                        TextAlignment="Left"
+                        ToolTip="{DynamicResource LocalizableSocketsInitBandwidthTooltip}"
+                        Value="{Binding SocketsInitBandwidth, TargetNullValue='', ValidatesOnDataErrors=True, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, NotifyOnValidationError=True}" />
+
+                    <Label
+                        Margin="{StaticResource LabelMargin}"
+                        HorizontalAlignment="Left"
+                        Content="{DynamicResource LocalizableSocketsMinBandwidthTitle}"
+                        FontSize="14"
+                        FontWeight="Bold" />
+                    <mah:NumericUpDown
+                        MinWidth="192"
+                        MaxWidth="512"
+                        Margin="{StaticResource EndControlMargin}"
+                        HorizontalAlignment="Left"
+                        mah:TextBoxHelper.ClearTextButton="True"
+                        Minimum="0"
+                        Speedup="True"
+                        TextAlignment="Left"
+                        ToolTip="{DynamicResource LocalizableSocketsMinBandwidthTooltip}"
+                        Value="{Binding SocketsMinBandwidth, TargetNullValue='', ValidatesOnDataErrors=True, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, NotifyOnValidationError=True}" />
+
+                    <Label
+                        Margin="{StaticResource LabelMargin}"
+                        HorizontalAlignment="Left"
+                        Content="{DynamicResource LocalizableSocketsMaxBandwidthTitle}"
+                        FontSize="14"
+                        FontWeight="Bold" />
+                    <mah:NumericUpDown
+                        MinWidth="192"
+                        MaxWidth="512"
+                        Margin="{StaticResource EndControlMargin}"
+                        HorizontalAlignment="Left"
+                        mah:TextBoxHelper.ClearTextButton="True"
+                        Minimum="0"
+                        Speedup="True"
+                        TextAlignment="Left"
+                        ToolTip="{DynamicResource LocalizableSocketsMaxBandwidthTooltip}"
+                        Value="{Binding SocketsMaxBandwidth, TargetNullValue='', ValidatesOnDataErrors=True, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, NotifyOnValidationError=True}" />
 
                 </StackPanel>
             </StackPanel>

--- a/ServerifyA3Tests/UniversalParserTests.cs
+++ b/ServerifyA3Tests/UniversalParserTests.cs
@@ -37,7 +37,10 @@ namespace ServerifyA3.Tests
                 MaxCustomFileSize = 160,
                 MaxMessagesSend = 321,
                 MaxSizeGuaranteed = 554,
-                MaxPacketSize = 321,
+                SocketsMaxPacketSize = 321,
+                SocketsInitBandwidth = 321,
+                SocketsMinBandwidth = 321,
+                SocketsMaxBandwidth = 321,
                 MaxSizeNonguaranteed = 213,
                 MinErrorToSend = 0.01F,
                 MinErrorToSendNear = 0.1F,
@@ -200,6 +203,9 @@ namespace ServerifyA3.Tests
                 "class sockets",
                 "{",
                 "maxPacketSize = 1400;",
+                "initBandwidth = 1250000;",
+                "MinBandwidth = 65536;",
+                "MaxBandwidth = 6250000;",
                 "};",
                 "adapter = -1;",
                 "MaxMsgSend = 128;",
@@ -213,7 +219,10 @@ namespace ServerifyA3.Tests
 
             Assert.NotNull(basicConfig);
             Assert.Equal(128, basicConfig.MaxMessagesSend);
-            Assert.Equal(1400, basicConfig.MaxPacketSize);
+            Assert.Equal(1400, basicConfig.SocketsMaxPacketSize);
+            Assert.Equal(1250000, basicConfig.SocketsInitBandwidth);
+            Assert.Equal(65536, basicConfig.SocketsMinBandwidth);
+            Assert.Equal(6250000, basicConfig.SocketsMaxBandwidth);
             Assert.True(Math.Abs(0.001F - basicConfig.MinErrorToSend.Value) < 0.00001);
             Assert.True(Math.Abs(25F - basicConfig.TerrainGridViewDistance.Value) < 0.00001);
             Assert.Equal(2000, basicConfig.ObjectViewDistance);


### PR DESCRIPTION
These properties default values are unchanged since OFP days when clients had 56k modems or maybe ISDN or ADSL. Increasing them makes mission download go immensely faster.

The default values are borrowed from https://gist.github.com/veteran29/ef08068262df808780fbcd4aeda0c03a

Since the property names inside the `class sockets` also exists outside the class config parser failed. I made an ugly workaround for it, any suggestions are welcomed before I change this from draft.

I'm not that fluent in neither German nor Russian so any help there would be appreciated. I can reach out to some of our German community friends if needed.