### PR TITLE
Fix startup crash in the newest update

### DIFF
--- a/A3ServerTool/Models/Config/ServerConfig.cs
+++ b/A3ServerTool/Models/Config/ServerConfig.cs
@@ -294,7 +294,7 @@ public class ServerConfig : IConfig
     /// Gets or sets a command for enabling or disabling the BattlEye anti-cheat engine.
     /// </summary>
     [ConfigProperty(PropertyName = "BattlEye")]
-    public bool HasBattleEye { get; set; } = true;
+    public int HasBattleEye { get; set; } = 1;
 
     /// <summary>
     /// Gets or sets timestamp format used on each report line in server-side RPT file.

--- a/A3ServerTool/ViewModels/ServerSubViewModels/SecurityViewModel.cs
+++ b/A3ServerTool/ViewModels/ServerSubViewModels/SecurityViewModel.cs
@@ -257,11 +257,12 @@ public class SecurityViewModel : ViewModelBase, IDataErrorInfo
     {
         get => CurrentProfile == null || CurrentProfile.ServerConfig == null
             ? false
-            : CurrentProfile.ServerConfig.HasBattleEye;
+            : (CurrentProfile.ServerConfig.HasBattleEye == 1);
         set
         {
-            if (Equals(value, CurrentProfile.ServerConfig.HasBattleEye)) return;
-            CurrentProfile.ServerConfig.HasBattleEye = value;
+            int valueInt = value ? 1 : 0;
+            if (Equals(valueInt, CurrentProfile.ServerConfig.HasBattleEye)) return;
+            CurrentProfile.ServerConfig.HasBattleEye = valueInt;
             RaisePropertyChanged();
         }
     }


### PR DESCRIPTION
The newest Arma 3 update makes the server crash with an access violation exception on startup when using this tool.
For some reason changing BattlEye=true/false to BattlEye=1/0 makes it work again.

idk either